### PR TITLE
[Config] fix kill-switch and fail-safe defects in the SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,96 @@
+# Changelog
+
+## 1.1.0 (unreleased)
+
+A fail-safe release. Every fix below closes a case where the SDK either injected a fault
+the operator had switched off, or silently injected nothing while reporting to Gremlin that
+it had. The minor bump is for one source-breaking change: `FailureFlag.enabled` is now a
+read-only property.
+
+### Fixed: the kill switch
+
+- **`FAILURE_FLAGS_ENABLED` is parsed instead of merely detected.** The SDK previously
+  enabled itself whenever the variable was present, whatever its value, so following the
+  install docs' instruction to set it to `false` for proxy mode left the SDK live and
+  injecting faults. `true`, `yes`, and `1` (case-insensitive) enable it; everything else,
+  including `false` and `""`, does not. Unset was the only way off before.
+- `enabled` is read from the environment on every access, so a `FailureFlag` constructed at
+  import time is no longer stuck with a stale answer.
+
+### Fixed: configuration that was silently discarded
+
+- **`GREMLIN_SIDECAR_PORT` now accepts the forms the sidecar accepts.** The sidecar reads
+  this variable as a listen address and requires a colon, so `:6032`, `0.0.0.0:6032`, and
+  `localhost:6032` are its normal values -- and the SDK parsed it as a bare integer and
+  discarded every one of them, quietly continuing to post to 5032. In a Pod where both
+  containers share the variable, moving the port meant no experiment ever ran again. All
+  four forms now resolve to the same endpoint; only the port is used, because a listen
+  address says what the sidecar binds, not where to reach it.
+- `FAILURE_FLAGS_ENDPOINT` must be `http` or `https`. `urlopen` would otherwise honour
+  `file://`, reading a local file and parsing it as experiments.
+- The fetch deadline is configurable: `FAILURE_FLAGS_TIMEOUT_MS` in milliseconds, or
+  `timeout=` in seconds on the constructor.
+
+### Fixed: effects that were silently ignored
+
+Each of these brings the SDK back in line with the Go and Node SDKs, and each changes when
+a fault actually fires.
+
+- **An experiment with no `rate` is applied.** An absent or `null` rate means 1.0. It used
+  to be fetched, reported as active, and never injected, so Gremlin recorded impact the
+  application never felt. A `rate` that is present but is not a number in 0..1 is still
+  skipped, and now says so in the debug log.
+- **A fractional latency is applied.** JSON has one number type, so `{"latency": 1000}` and
+  `{"latency": 1000.0}` are the same instruction, but only the whole number worked. A
+  fractional `ms` inside a `latency` object was worse: it reported impact while sleeping
+  zero.
+- **A latency clause that resolves to no delay is no longer reported as impact.**
+  `{"latency": {}}`, a negative delay, and a non-numeric `ms` all used to claim impact after
+  sleeping zero. A negative delay also raised out of `time.sleep()` into the effect's own
+  exception handler.
+- **Infinite and `NaN` delays are rejected.** `time.sleep(inf)` hangs the caller forever.
+- **The documented `name` key selects the exception type.** The cross-language error
+  metadata form, `{"message": ..., "name": "TimeoutError"}`, was ignored: the SDK read only
+  `module` and `className`, so the documented payload fell through to `ValueError`.
+  `className` still wins when both are present.
+- An experiment whose exception class cannot be loaded now raises a `ValueError` carrying
+  the experiment's message rather than nothing at all. A class that resolves to a
+  non-exception still falls back to `ValueError` rather than being called.
+
+### Fixed: `invoke()` raising when it promised not to
+
+`invoke()` documents that it never raises unless an active experiment says so. These all
+broke that promise on the request path the library exists to protect:
+
+- A non-string flag name (`None` out of a dict `.get()` is the ordinary way to get one)
+  raised `TypeError: object of type 'NoneType' has no len()`.
+- A non-callable `behavior=` raised `TypeError` whenever an experiment was active.
+- A malformed sidecar response raised `KeyError('rate')`, or a `TypeError` for a non-dict
+  experiment or a null effect.
+- `labels` of the wrong type raised out of the request builder.
+
+### Fixed: sidecar responses that are not trusted input
+
+- **A `Content-Type` parameter no longer silences the SDK.** `application/json;
+  charset=utf-8` is legal and common, and the header was compared exactly, so any proxy
+  adding a parameter would have taken the whole Python fleet quiet with nothing but a debug
+  log. Only the media type is compared now.
+- A whitespace-only body with a positive `Content-Length` reached `json.loads("")` and
+  raised out of the public `fetch()`.
+- The no-experiment case is a bare `204`, which is now answered before the header checks
+  instead of logging `unexpected Content-Type:` on every single call.
+
+### Fixed: shared and borrowed state
+
+- **`FailureFlag.data` is no longer a shared mutable default.** `data={}` was evaluated once
+  at import, so every flag built without an explicit `data=` shared one dict process-wide.
+- **`fetch()` no longer mutates the caller's `labels` dict.** It annotated the dict it was
+  handed with `failure-flags-sdk-version`, so a module-level or reused dict silently grew a
+  Gremlin key that then showed up in whatever else that dict fed. A copy is annotated now.
+  As a side effect `labels=None` sends `{}` instead of raising.
+
+### Breaking
+
+- **`FailureFlag.enabled` is a read-only property.** Through 1.0.3 it was a plain attribute,
+  so `flag.enabled = False` worked; it now raises `AttributeError`. Patch
+  `FAILURE_FLAGS_ENABLED` in the environment instead. See the README for the migration.

--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ The rest of the SDK's configuration comes from the environment too, and every va
 | Variable | Default | Description |
 | --- | --- | --- |
 | `FAILURE_FLAGS_ENABLED` | unset | Set to `true`, `yes`, or `1` (case-insensitive) to enable the SDK. Anything else disables it. |
-| `FAILURE_FLAGS_ENDPOINT` | `http://localhost:5032/experiment` | The full sidecar URL. Takes precedence over the host and port variables below. |
+| `FAILURE_FLAGS_ENDPOINT` | `http://localhost:5032/experiment` | The full sidecar URL. Takes precedence over the host and port variables below. Must be `http` or `https`; anything else is ignored. |
 | `GREMLIN_SIDECAR_HOST` | `localhost` | The sidecar host, matching the sidecar's own configuration namespace. |
-| `GREMLIN_SIDECAR_PORT` | `5032` | The sidecar port. A value outside 1..65535 falls back to the default. |
+| `GREMLIN_SIDECAR_PORT` | `5032` | The sidecar port. The sidecar reads this same variable as a *listen address*, so `6032`, `:6032`, `0.0.0.0:6032`, and `localhost:6032` are all accepted and all mean port 6032. Only the port is used: a listen address says what the sidecar binds, not where to reach it. A port outside 1..65535 falls back to the default. |
 | `FAILURE_FLAGS_TIMEOUT_MS` | `1` | The fetch deadline in **milliseconds**. The sidecar is a co-process on loopback, so this is deliberately tight. |
 
 The `endpoint` and `timeout` keyword arguments to `FailureFlag` override the corresponding variables. Mind the units: `timeout` is in seconds (`timeout=.005`), `FAILURE_FLAGS_TIMEOUT_MS` is in milliseconds.
@@ -87,6 +87,12 @@ Every variable is read on each call, so a `FailureFlag` constructed at import ti
 ### Changed since 1.0.3
 
 `FAILURE_FLAGS_ENABLED` used to enable the SDK whenever the variable was *present*, whatever its value. Setting it to `false`, as the install docs tell proxy-mode users to do, left the SDK live and injecting faults. The value is now parsed, so `false`, `no`, `0`, and `""` all disable the SDK.
+
+Three effect-processing changes bring this SDK back in line with the Go and Node SDKs. Each one used to be a silent no-op, and every one of them changes when a fault actually fires:
+
+- **An experiment with no `rate` is now applied.** An absent or `null` rate means 1.0. Previously the experiment was fetched and reported as active, but nothing was injected, so Gremlin recorded an experiment the application never felt. A `rate` that is present but is not a number in 0..1 is still skipped.
+- **A fractional latency is now applied.** JSON has one number type, so `{"latency": 1000}` and `{"latency": 1000.0}` are the same instruction. The SDK accepted only whole numbers, so a fractional latency did nothing, and a fractional `ms` inside a `latency` object reported impact while sleeping zero. Both forms now work, as do numeric strings.
+- **A latency clause that resolves to no delay is no longer reported as impact.** `{"latency": {}}`, a negative delay, and a non-numeric `ms` used to return "impacted" after sleeping zero. Infinite and `NaN` delays are rejected outright rather than hanging the caller.
 
 One consequence: `FailureFlag.enabled` is now a read-only property backed by the environment. If you were disabling a flag by assigning to it, patch the environment instead:
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,36 @@ def lambda_handler(event, context):
 
 ## Enabling the SDK in your Environment
 
-*Don't forget to enable the SDK by setting the FAILURE_FLAGS_ENABLED environment variable!* If this environment variable is not set then the SDK will short-circuit and no attempt to fetch experiments will be made.
+*Don't forget to enable the SDK by setting the FAILURE_FLAGS_ENABLED environment variable to `true`, `yes`, or `1`!* Any other value, including `false`, and any unset variable leaves the SDK short-circuited, and no attempt to fetch experiments will be made.
+
+The rest of the SDK's configuration comes from the environment too, and every variable is optional:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `FAILURE_FLAGS_ENABLED` | unset | Set to `true`, `yes`, or `1` (case-insensitive) to enable the SDK. Anything else disables it. |
+| `FAILURE_FLAGS_ENDPOINT` | `http://localhost:5032/experiment` | The full sidecar URL. Takes precedence over the host and port variables below. |
+| `GREMLIN_SIDECAR_HOST` | `localhost` | The sidecar host, matching the sidecar's own configuration namespace. |
+| `GREMLIN_SIDECAR_PORT` | `5032` | The sidecar port. A value outside 1..65535 falls back to the default. |
+| `FAILURE_FLAGS_TIMEOUT_MS` | `1` | The fetch deadline in **milliseconds**. The sidecar is a co-process on loopback, so this is deliberately tight. |
+
+The `endpoint` and `timeout` keyword arguments to `FailureFlag` override the corresponding variables. Mind the units: `timeout` is in seconds (`timeout=.005`), `FAILURE_FLAGS_TIMEOUT_MS` is in milliseconds.
+
+Every variable is read on each call, so a `FailureFlag` constructed at import time still picks up configuration that the process sets later.
+
+### Changed since 1.0.3
+
+`FAILURE_FLAGS_ENABLED` used to enable the SDK whenever the variable was *present*, whatever its value. Setting it to `false`, as the install docs tell proxy-mode users to do, left the SDK live and injecting faults. The value is now parsed, so `false`, `no`, `0`, and `""` all disable the SDK.
+
+One consequence: `FailureFlag.enabled` is now a read-only property backed by the environment. If you were disabling a flag by assigning to it, patch the environment instead:
+
+```python
+# no longer works: raises AttributeError
+flag.enabled = False
+
+# do this instead
+with unittest.mock.patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "false"}):
+    flag.invoke()
+```
 
 ## Extensibility
 
@@ -196,7 +225,7 @@ If your app uses custom error types or other error condition metadata then use t
 }
 ```
 
-If `module` is omitted the SDK will assume `builtins`. If `className` is omitted the SDK will assume `ValueError`.
+If `module` is omitted the SDK will assume `builtins`. If `className` is omitted the SDK will assume `ValueError`. `name` works as an alias for `className`, so the cross-language error metadata form (`{"message": ..., "name": ...}`) does what you would expect here; `className` wins if you provide both. If the named class cannot be imported the SDK raises a `ValueError` carrying your `message` rather than nothing at all.
 
 ### Combining the Two for a "Delayed Exception"
 

--- a/src/failureflags/__init__.py
+++ b/src/failureflags/__init__.py
@@ -1,5 +1,6 @@
 from urllib.request import urlopen, Request
 from random import random
+from math import isfinite
 import json
 import os
 import time
@@ -25,6 +26,10 @@ DEFAULT_HOST = "localhost"
 DEFAULT_PORT = 5032
 DEFAULT_TIMEOUT = .001 # seconds
 
+# The sidecar speaks HTTP. Anything else in FAILURE_FLAGS_ENDPOINT is a misconfiguration,
+# and urlopen would happily honour file:// or ftp:// if we passed it along.
+ALLOWED_SCHEMES = ("http://", "https://")
+
 def cleanString(value):
     """Returns `value` trimmed if it is a non-empty string, otherwise None."""
     if type(value) is not str:
@@ -42,27 +47,53 @@ def isEnabled(raw):
     """
     return raw is not None and raw.strip().lower() in ENABLED_VALUES
 
-def resolveEndpoint(explicit, endpointVariable, hostVariable, portVariable):
+def parsePort(raw, debug=False):
+    """Extracts a TCP port from a GREMLIN_SIDECAR_PORT value, or None if there isn't one.
+
+    The sidecar reads this variable as a *listen address* and requires a colon, so in a Pod
+    where both containers share it -- the whole reason for reusing the sidecar's name -- the
+    value is `:6032`, `0.0.0.0:6032`, or `host:6032`, not a bare `6032`. Parsing it as a
+    plain integer silently discarded every value the sidecar accepts, so accept all four
+    forms and keep only the port.
+
+    The host half is deliberately ignored: a listen address says what the sidecar binds, not
+    where to reach it, and `0.0.0.0` is not a connect target. Use GREMLIN_SIDECAR_HOST to
+    move the host.
+    """
+    global logger
+    try:
+        port = int(raw.rsplit(":", 1)[-1].strip())
+    except ValueError:
+        port = -1
+    if port > 0 and port <= 65535:
+        return port
+    if debug:
+        logger.debug(f"ignoring unusable {ENV_SIDECAR_PORT} value {raw!r}, using {DEFAULT_PORT}")
+    return None
+
+def resolveEndpoint(explicit, endpointVariable, hostVariable, portVariable, debug=False):
     """Resolves the sidecar URL, most specific source first: the `endpoint` argument, then
     FAILURE_FLAGS_ENDPOINT, then GREMLIN_SIDECAR_HOST and GREMLIN_SIDECAR_PORT (either may
     be set alone), then http://localhost:5032/experiment.
 
-    A port that is not a number in 1..65535 falls back to the default rather than raising.
-    This is a fail-safe library; bad configuration must not take the application with it.
+    A port that is not a number in 1..65535, and an endpoint that is not HTTP, fall back to
+    the default rather than raising. This is a fail-safe library; bad configuration must not
+    take the application with it.
     """
+    global logger
     endpoint = cleanString(explicit) or cleanString(endpointVariable)
     if endpoint is not None:
-        return endpoint
+        if endpoint.lower().startswith(ALLOWED_SCHEMES):
+            return endpoint
+        if debug:
+            logger.debug(f"ignoring endpoint {endpoint!r}: only http and https are supported")
     host = cleanString(hostVariable) or DEFAULT_HOST
     port = DEFAULT_PORT
     raw = cleanString(portVariable)
     if raw is not None:
-        try:
-            parsed = int(raw)
-            if parsed > 0 and parsed <= 65535:
-                port = parsed
-        except ValueError:
-            pass # keep the default
+        parsed = parsePort(raw, debug)
+        if parsed is not None:
+            port = parsed
     return f"http://{host}:{port}/experiment"
 
 def resolveTimeout(explicit, timeoutVariable):
@@ -82,19 +113,37 @@ def resolveTimeout(explicit, timeoutVariable):
             pass # keep the default
     return DEFAULT_TIMEOUT
 
-def isSelected(experiment, dice):
-    """True when `experiment` is well-formed, its `rate` is a number in [0,1], and `dice`
-    landed under that rate.
+def isSelected(experiment, dice, debug=False):
+    """True when `experiment` is well-formed and `dice` landed under its `rate`.
+
+    An absent or null `rate` means 1.0, always apply, which is what the Go and Node SDKs do
+    (Go declares the field and never reads it; Node only drops an experiment when `rate` is
+    a valid number and the dice lose). Requiring one made a payload without a rate a silent
+    no-op that still reported `active`, so Gremlin saw an experiment that injected nothing.
+
+    A `rate` that is present but is not a number in [0,1] is malformed: skip it and say so,
+    rather than guessing which direction the operator meant.
 
     Anything malformed is simply not selected. The sidecar response is not trusted input
     and `invoke()` promises never to raise on its own.
     """
+    global logger
     if not isinstance(experiment, dict):
+        if debug:
+            logger.debug("experiment is not an object, not selected")
         return False
     rate = experiment.get("rate")
-    if type(rate) is not int and type(rate) is not float:
+    if rate is None:
+        rate = 1
+    if (type(rate) is not int and type(rate) is not float) or not isfinite(rate):
+        if debug:
+            logger.debug(f"experiment rate {rate!r} is not a number, not selected")
         return False
-    return rate >= 0 and rate <= 1 and dice < rate
+    if rate < 0 or rate > 1:
+        if debug:
+            logger.debug(f"experiment rate {rate!r} is outside [0,1], not selected")
+        return False
+    return dice < rate
 
 class FailureFlag:
     """FailureFlag represents a point in your code where you want to be able to inject failures dynamically.
@@ -181,9 +230,12 @@ class FailureFlag:
             if self.debug:
                 logger.debug("SDK not enabled")
             return (active, impacted, experiments)
-        if len(self.name) <= 0:
+        if not isinstance(self.name, str) or len(self.name) == 0:
+            # a name straight out of a dict .get() or a config lookup is an ordinary way to
+            # arrive here holding None, and len(None) took down the request path this
+            # library exists to make more reliable
             if self.debug:
-                logger.debug("no failure flag name specified")
+                logger.debug(f"no usable failure flag name specified: {self.name!r}")
             return (active, impacted, experiments)
         try:
             experiments = self.fetch()
@@ -194,7 +246,12 @@ class FailureFlag:
         if len(experiments) > 0:
             active = True
             dice = random()
-            impacted = self.behavior(self, [e for e in experiments if isSelected(e, dice)])
+            selected = [e for e in experiments if isSelected(e, dice, self.debug)]
+            if callable(self.behavior):
+                # the behavior is allowed to raise: that is the injected fault
+                impacted = self.behavior(self, selected)
+            elif self.debug:
+                logger.debug(f"configured behavior {self.behavior!r} is not callable, skipping")
         else:
             if self.debug:
                 logger.debug("no experiments retrieved")
@@ -213,13 +270,18 @@ class FailureFlag:
         if not self.enabled:
             return experiments
         # annotate a copy: the labels dict belongs to the caller
-        labels = dict(self.labels) if self.labels else {}
+        labels = {}
+        if isinstance(self.labels, dict):
+            labels = dict(self.labels)
+        elif self.labels is not None and self.debug:
+            logger.debug(f"labels {self.labels!r} is not a dict, sending none")
         labels["failure-flags-sdk-version"] = f"python-{VERSION}"
         data = json.dumps({"name": self.name, "labels": labels}).encode("utf-8")
         endpoint = resolveEndpoint(self.endpoint,
                                    os.environ.get(ENV_ENDPOINT),
                                    os.environ.get(ENV_SIDECAR_HOST),
-                                   os.environ.get(ENV_SIDECAR_PORT))
+                                   os.environ.get(ENV_SIDECAR_PORT),
+                                   self.debug)
         timeout = resolveTimeout(self.timeout, os.environ.get(ENV_TIMEOUT_MS))
         request = Request(endpoint,
                           headers={"Content-Type": "application/json", "Content-Length": len(data)},
@@ -231,8 +293,18 @@ class FailureFlag:
                     logger.debug(f"bad status code ({code}) while fetching experiments")
                 return []
 
-            # Validate Content-Type
-            content_type = response.headers.get("Content-Type", "").lower()
+            # No experiments is the normal case and the sidecar says so with a bare 204,
+            # no Content-Type and no Content-Length. Answer it before the header checks
+            # below, which would otherwise log a scary line on every single call.
+            if code == 204:
+                if self.debug:
+                    logger.debug("no experiments (204 No Content)")
+                return []
+
+            # Validate Content-Type. Compare the media type only: `application/json;
+            # charset=utf-8` is legal and common, and matching the whole header exactly
+            # meant one proxy adding a parameter would silence the SDK fleet-wide.
+            content_type = response.headers.get("Content-Type", "").split(";")[0].strip().lower()
             if content_type != "application/json":
                 if self.debug:
                     logger.debug(f"unexpected Content-Type: {content_type}")
@@ -248,10 +320,16 @@ class FailureFlag:
             # Read the response body
             body = response.read().decode('utf-8').strip()  # Decode and strip whitespace
             response.close()
+            if len(body) == 0:
+                # a positive Content-Length with a whitespace-only body reached
+                # json.loads("") and raised out of the public fetch()
+                if self.debug:
+                    logger.debug("empty response body")
+                return []
             experiments = json.loads(body)
-            if isinstance(experiments, list) or type(experiments) is list:
+            if isinstance(experiments, list):
                 return experiments
-            elif isinstance(experiments, dict) or type(experiments) is dict:
+            elif isinstance(experiments, dict):
                 return [experiments]
             else:
                 return []
@@ -268,6 +346,36 @@ def delayedDataOrError(failureflag, experiments):
     dataImpact = data(failureflag, experiments)
     return latencyImpact or exceptionImpact or dataImpact
 
+def asMilliseconds(value):
+    """Returns `value` as a non-negative float of milliseconds, or None if it is not a
+    usable number.
+
+    JSON has a single number type, so an effect the control plane serialises as `1000`
+    arrives as an int and `1000.0` arrives as a float. Accepting only int made a float
+    latency a silent no-op, and made a float `ms` inside a latency object report impact
+    while sleeping zero. Both are numbers; treat them alike, as Node does with `typeof
+    latency === "number"`.
+
+    Strings are accepted because the effect editor allows them. Booleans are not numbers
+    here. NaN and infinity are rejected outright: `time.sleep(inf)` hangs the caller
+    forever, which is the one thing this library must never do. Negatives clamp to zero so
+    a nonsensical value is no impact rather than a ValueError out of time.sleep().
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        ms = float(value)
+    elif isinstance(value, str):
+        try:
+            ms = float(value)
+        except ValueError:
+            return None
+    else:
+        return None
+    if not isfinite(ms):
+        return None
+    return ms if ms > 0 else 0.0
+
 def latency(ff, experiments):
     """`latency` processes `latency` clauses in effect statements for each provided experiment in the list."""
     impacted = False
@@ -278,7 +386,7 @@ def latency(ff, experiments):
                 logger.debug("experiments was empty")
             return impacted
         for e in experiments:
-            if not isinstance(e, dict) or type(e) is not dict:
+            if not isinstance(e, dict):
                 if ff.debug:
                     logger.debug("experiment is not a dict, skipping")
                 continue
@@ -290,27 +398,29 @@ def latency(ff, experiments):
                 if ff.debug:
                     logger.debug("no latency in experiment effect, skipping")
                 continue
-            if type(e["effect"]["latency"]) is int:
-                impacted = True
-                time.sleep(e["effect"]["latency"]/1000)
-            elif type(e["effect"]["latency"]) is str:
-                try: 
-                    ms = int(e["effect"]["latency"])
-                    time.sleep(ms/1000)
-                    impacted = True
-                except ValueError as err:
+            clause = e["effect"]["latency"]
+            if isinstance(clause, dict):
+                ms = asMilliseconds(clause.get("ms"))
+                jitter = asMilliseconds(clause.get("jitter"))
+                if ms is None and jitter is None:
                     if ff.debug:
-                        logger.debug("experiment contained a non-number latency clause")
-            elif isinstance(e["effect"]["latency"], dict):
-                impacted = True
-                ms = 0
-                jitter = 0
-                if "ms" in e["effect"]["latency"] and type(e["effect"]["latency"]["ms"]) is int:
-                    ms = e["effect"]["latency"]["ms"]
-                if "jitter" in e["effect"]["latency"] and type(e["effect"]["latency"]["jitter"]) is int:
-                    jitter = e["effect"]["latency"]["jitter"]
-                # convert both ms and jitter to seconds
-                time.sleep(ms/1000 + jitter*random()/1000)
+                        logger.debug(f"latency clause {clause!r} carries no usable delay, skipping")
+                    continue
+                delay = (ms or 0) + (jitter or 0)*random()
+            else:
+                delay = asMilliseconds(clause)
+                if delay is None:
+                    if ff.debug:
+                        logger.debug(f"experiment contained a non-number latency clause: {clause!r}")
+                    continue
+            if delay <= 0:
+                # claiming impact for a clause that resolves to no delay reports a fault
+                # to Gremlin that the application never felt
+                if ff.debug:
+                    logger.debug(f"latency clause {clause!r} resolved to {delay}ms, skipping")
+                continue
+            impacted = True
+            time.sleep(delay/1000)
     except Exception as oerr:
         if ff.debug:
             logger.debug(f"experiments caused an exception to be thrown in latency, {oerr}")
@@ -355,7 +465,7 @@ def exception(ff, experiments):
     """
     global logger
     for f in experiments:
-        if not isinstance(f, dict) or type(f) is not dict:
+        if not isinstance(f, dict):
             continue
         if "effect" not in f or not isinstance(f["effect"], dict):
             continue

--- a/src/failureflags/__init__.py
+++ b/src/failureflags/__init__.py
@@ -1,7 +1,6 @@
 from urllib.request import urlopen, Request
 from random import random
 import json
-import collections
 import os
 import time
 
@@ -13,6 +12,90 @@ logger.addHandler(NullHandler())
 
 VERSION = "1.0.3"
 
+ENV_ENABLED = "FAILURE_FLAGS_ENABLED"
+ENV_ENDPOINT = "FAILURE_FLAGS_ENDPOINT"
+ENV_TIMEOUT_MS = "FAILURE_FLAGS_TIMEOUT_MS"
+ENV_SIDECAR_HOST = "GREMLIN_SIDECAR_HOST"
+ENV_SIDECAR_PORT = "GREMLIN_SIDECAR_PORT"
+
+# The values of FAILURE_FLAGS_ENABLED that turn the SDK on.
+ENABLED_VALUES = frozenset(("true", "yes", "1"))
+
+DEFAULT_HOST = "localhost"
+DEFAULT_PORT = 5032
+DEFAULT_TIMEOUT = .001 # seconds
+
+def cleanString(value):
+    """Returns `value` trimmed if it is a non-empty string, otherwise None."""
+    if type(value) is not str:
+        return None
+    value = value.strip()
+    return value if len(value) > 0 else None
+
+def isEnabled(raw):
+    """True when `raw` is one of the documented enabling values: `true`, `yes`, or `1`,
+    case-insensitive. Absent, empty, and anything else means disabled.
+
+    Testing for the presence of the variable rather than its value would make
+    FAILURE_FLAGS_ENABLED=false *enable* fault injection, which is the wrong direction
+    for a kill switch.
+    """
+    return raw is not None and raw.strip().lower() in ENABLED_VALUES
+
+def resolveEndpoint(explicit, endpointVariable, hostVariable, portVariable):
+    """Resolves the sidecar URL, most specific source first: the `endpoint` argument, then
+    FAILURE_FLAGS_ENDPOINT, then GREMLIN_SIDECAR_HOST and GREMLIN_SIDECAR_PORT (either may
+    be set alone), then http://localhost:5032/experiment.
+
+    A port that is not a number in 1..65535 falls back to the default rather than raising.
+    This is a fail-safe library; bad configuration must not take the application with it.
+    """
+    endpoint = cleanString(explicit) or cleanString(endpointVariable)
+    if endpoint is not None:
+        return endpoint
+    host = cleanString(hostVariable) or DEFAULT_HOST
+    port = DEFAULT_PORT
+    raw = cleanString(portVariable)
+    if raw is not None:
+        try:
+            parsed = int(raw)
+            if parsed > 0 and parsed <= 65535:
+                port = parsed
+        except ValueError:
+            pass # keep the default
+    return f"http://{host}:{port}/experiment"
+
+def resolveTimeout(explicit, timeoutVariable):
+    """Resolves the fetch deadline in seconds, most specific source first: the `timeout`
+    argument (seconds), then FAILURE_FLAGS_TIMEOUT_MS (milliseconds, matching the other
+    SDKs), then DEFAULT_TIMEOUT. Non-positive and unparsable values fall back.
+    """
+    if (type(explicit) is int or type(explicit) is float) and explicit > 0:
+        return explicit
+    raw = cleanString(timeoutVariable)
+    if raw is not None:
+        try:
+            ms = float(raw)
+            if ms > 0:
+                return ms/1000
+        except ValueError:
+            pass # keep the default
+    return DEFAULT_TIMEOUT
+
+def isSelected(experiment, dice):
+    """True when `experiment` is well-formed, its `rate` is a number in [0,1], and `dice`
+    landed under that rate.
+
+    Anything malformed is simply not selected. The sidecar response is not trusted input
+    and `invoke()` promises never to raise on its own.
+    """
+    if not isinstance(experiment, dict):
+        return False
+    rate = experiment.get("rate")
+    if type(rate) is not int and type(rate) is not float:
+        return False
+    return rate >= 0 and rate <= 1 and dice < rate
+
 class FailureFlag:
     """FailureFlag represents a point in your code where you want to be able to inject failures dynamically.
     
@@ -20,27 +103,50 @@ class FailureFlag:
     invoke() function is called. Instead of relying on the built-in behavior processing a user can call the
     fetch() function to simply retrieve any active experiments targeting a FailureFlag.
 
-    This package is inert if the FAILURE_FLAGS_ENABLED environment variable is unset.
+    This package is inert unless the FAILURE_FLAGS_ENABLED environment variable is set to
+    `true`, `yes`, or `1`.
 
     This package sends debug logs to a logger named `failureflags`.
     """
 
-    def __init__(self, name, labels, behavior=None, data={}, debug=False, timeout=.001):
+    def __init__(self, name, labels, behavior=None, data=None, debug=False, timeout=None, endpoint=None):
         """Create a new FailureFlag.
 
         Keyword arguments:
         behavior -- a function to invoke for retrieved experiments instead of the default behavior chain.
         debug -- True or False (default False) to control debug logging.
         data -- Data to be mutated by behaviors and effect data.
+        timeout -- the fetch deadline in seconds. Overrides FAILURE_FLAGS_TIMEOUT_MS. Note
+                   the units: this argument is seconds, the environment variable is
+                   milliseconds. Defaults to DEFAULT_TIMEOUT.
+        endpoint -- the sidecar URL. Overrides FAILURE_FLAGS_ENDPOINT and
+                    GREMLIN_SIDECAR_HOST/GREMLIN_SIDECAR_PORT.
+
+        `timeout` and `endpoint` are stored as provided; None means "not specified" and
+        leaves the environment in charge. Read the values actually used from
+        `resolveTimeout` and `resolveEndpoint`.
         """
         
-        self.enabled = 'FAILURE_FLAGS_ENABLED' in os.environ
         self.name = name
         self.labels = labels
         self.behavior = behavior if behavior != None else defaultBehavior
-        self.data = data 
+        self.data = {} if data is None else data
         self.debug = True if debug != False else False # filter out any other possible values that might be provided
         self.timeout = timeout
+        self.endpoint = endpoint
+
+    @property
+    def enabled(self):
+        """True when FAILURE_FLAGS_ENABLED is set to `true`, `yes`, or `1` (case-insensitive).
+
+        Read from the environment on each access, so a FailureFlag constructed at import
+        time, before the process environment is fully configured, is not stuck with a
+        stale answer.
+
+        Read-only: through 1.0.3 this was a plain attribute, so assigning to it worked.
+        Set the environment variable instead.
+        """
+        return isEnabled(os.environ.get(ENV_ENABLED))
 
     def __str__(self):
         return f"<FailureFlag name:{self.name} labels:{self.labels} debug:{self.debug}>"
@@ -53,7 +159,8 @@ class FailureFlag:
         either the configured custom behavior or the default behavior chain.
 
         Like `fetch()` calls to `invoke()` will shortcut any experiment lookup or application if
-        the SDK has not been explicitly enabled by setting FAILURE_FLAGS_ENABLED to any value.
+        the SDK has not been explicitly enabled by setting FAILURE_FLAGS_ENABLED to `true`,
+        `yes`, or `1`.
 
         Unlike `fetch()` this function will never raise any Exception unless there is an active
         experiment configured to do so. 
@@ -82,19 +189,12 @@ class FailureFlag:
             experiments = self.fetch()
         except Exception as err:
             if self.debug:
-                logger.debug("received error while fetching experiments", err)
+                logger.debug(f"received error while fetching experiments, {err}")
             return (active, impacted, experiments)
         if len(experiments) > 0:
             active = True
-            # TODO dice roll
             dice = random()
-            filteredExperiments = filter(lambda experiment: 
-                                         (type(experiment["rate"]) is float 
-                                         or type(experiment["rate"]) is int)
-                                         and experiment["rate"] >= 0 
-                                         and experiment["rate"] <= 1 
-                                         and dice < experiment["rate"], experiments)
-            impacted = self.behavior(self, list(filteredExperiments))
+            impacted = self.behavior(self, [e for e in experiments if isSelected(e, dice)])
         else:
             if self.debug:
                 logger.debug("no experiments retrieved")
@@ -112,12 +212,19 @@ class FailureFlag:
         experiments = []
         if not self.enabled:
             return experiments
-        self.labels["failure-flags-sdk-version"] = f"python-{VERSION}"
-        data = json.dumps({"name": self.name, "labels": self.labels}).encode("utf-8")
-        request = Request('http://localhost:5032/experiment',
+        # annotate a copy: the labels dict belongs to the caller
+        labels = dict(self.labels) if self.labels else {}
+        labels["failure-flags-sdk-version"] = f"python-{VERSION}"
+        data = json.dumps({"name": self.name, "labels": labels}).encode("utf-8")
+        endpoint = resolveEndpoint(self.endpoint,
+                                   os.environ.get(ENV_ENDPOINT),
+                                   os.environ.get(ENV_SIDECAR_HOST),
+                                   os.environ.get(ENV_SIDECAR_PORT))
+        timeout = resolveTimeout(self.timeout, os.environ.get(ENV_TIMEOUT_MS))
+        request = Request(endpoint,
                           headers={"Content-Type": "application/json", "Content-Length": len(data)},
                           data=data)
-        with urlopen(request, timeout=self.timeout) as response:
+        with urlopen(request, timeout=timeout) as response:
             code = response.status if hasattr(response, 'status') else 0
             if code < 200 or code >= 300:
                 if self.debug:
@@ -175,7 +282,7 @@ def latency(ff, experiments):
                 if ff.debug:
                     logger.debug("experiment is not a dict, skipping")
                 continue
-            if "effect" not in e:
+            if "effect" not in e or not isinstance(e["effect"], dict):
                 if ff.debug:
                     logger.debug("no effect in experiment, skipping")
                 continue
@@ -209,24 +316,48 @@ def latency(ff, experiments):
             logger.debug(f"experiments caused an exception to be thrown in latency, {oerr}")
     return impacted
 
+def loadException(module, class_name, message, debug=False):
+    """Builds the Exception named by `module` and `class_name` with `message` as its sole
+    argument, falling back to a ValueError carrying `message` when that name cannot be
+    resolved.
+
+    This never returns None on purpose. An experiment that cannot load its class must
+    still raise something, or Gremlin reports impact while the application saw nothing at
+    all.
+    """
+    global logger
+    module_name = module if module is not None else "builtins"
+    try:
+        module_ = __import__(module_name, fromlist=[class_name])
+        error = getattr(module_, class_name)(message)
+        if not isinstance(error, BaseException):
+            # `raise` would throw a TypeError of our own making from the caller's line
+            raise TypeError(f"{module_name}.{class_name} is not an exception type")
+        return error
+    except Exception as err:
+        if debug:
+            logger.debug(f"unable to load {module_name}.{class_name}, falling back to ValueError, {err}")
+        return ValueError(message)
+
 def exception(ff, experiments):
     """`exception` processes `exception` clauses in effect statements for each provided experiment in the list.
 
     `exception` clauses may be simple strings, or dictionaries. If an experiment provides
     a simple string then this function will raise a `ValueError` and use the string as the
-    message. If the experiment specified a dict then this function will look for three
-    keys: `module`, `className`, and `message`. If `module` is provided then this 
+    message. If the experiment specified a dict then this function will look for four
+    keys: `module`, `className`, `name`, and `message`. If `module` is provided then this 
     function will attempt to import that module, and get a reference to the item in that 
-    module with the name provided in `className`. If `module` is not provided then this 
-    function attempts to load `className` from `builtins`. This function always provides
-    The value for `message` as the sole argument when invoking the function identified by
-    `className`.
+    module with the name provided in `className` (or `name`, its cross-language alias;
+    `className` wins when both are present). If `module` is not provided then this 
+    function attempts to load the class from `builtins`. If the class cannot be loaded
+    then a `ValueError` is raised instead. This function always provides the value for
+    `message` as the sole argument when invoking the function identified by `className`.
     """
     global logger
     for f in experiments:
         if not isinstance(f, dict) or type(f) is not dict:
             continue
-        if "effect" not in f:
+        if "effect" not in f or not isinstance(f["effect"], dict):
             continue
         if "exception" not in f["effect"]:
             continue
@@ -234,42 +365,33 @@ def exception(ff, experiments):
             # this is the feature
             raise ValueError(f["effect"]["exception"])
         elif isinstance(f["effect"]["exception"], dict):
-            module = "builtins"
-            class_name = "ValueError"
+            clause = f["effect"]["exception"]
+            module = None
+            class_name = None
             message = "Error injected via Gremlin Failure Flags (default message)"
             hasKnown = False
-            if "module" in f["effect"]["exception"] and type(f["effect"]["exception"]["module"]) is str:
-                module = f["effect"]["exception"]["module"]
+            if type(clause.get("module")) is str:
+                module = clause["module"]
                 hasKnown = True
-            if "className" in f["effect"]["exception"] and type(f["effect"]["exception"]["className"]) is str:
-                class_name= f["effect"]["exception"]["className"]
-                hasKnown = True
-            if "message" in f["effect"]["exception"] and type(f["effect"]["exception"]["message"]) is str:
-                message = f["effect"]["exception"]["message"]
+            # `name` is the documented cross-language key for the exception type and
+            # `className` is the Python-specific alias, so `className` wins when both
+            # are present.
+            for key in ("name", "className"):
+                if type(clause.get(key)) is str:
+                    class_name = clause[key]
+                    hasKnown = True
+            if type(clause.get("message")) is str:
+                message = clause["message"]
                 hasKnown = True
             if not hasKnown:
                 if ff.debug:
                     logger.debug("exception clause was not populated")
                 continue
-            if len(class_name) == 0:
+            if class_name is not None and len(class_name) == 0:
                 # for some reason this was explicitly unset
                 continue
-            error = None
-            try:
-                if module is not None:
-                    module_ = __import__(module, fromlist=[None])
-                    class_ = getattr(module_, class_name)
-                else: 
-                    class_ = globals()[class_name]
-                error = class_(message)
-            except Exception as err:
-                # unable to load the class
-                if ff.debug:
-                    logger.debug(f"unable to load the named module: {module}, {err}")
-                return False
-            if error is not None:
-                # this is the acceptable place to raise an exception
-                raise error
+            # this is the acceptable place to raise an exception
+            raise loadException(module, class_name if class_name is not None else "ValueError", message, ff.debug)
     return False
 
 def data(ff, experiments):

--- a/test/behaviors_test.py
+++ b/test/behaviors_test.py
@@ -382,5 +382,95 @@ class TestFailureFlagsBehaviors(unittest.TestCase):
             return
         assert False, "the well-formed experiment in the list must still be applied"
 
+class TestLatencyNumbers(unittest.TestCase):
+    """JSON has one number type. Accepting only int made a float latency a silent no-op,
+    and made a float `ms` report impact while sleeping zero."""
+
+    def latency(self, clause):
+        flag = failureflags.FailureFlag("name", {}, debug=True)
+        return failureflags.latency(flag, [{"rate": 1, "effect": {"latency": clause}}])
+
+    @patch('failureflags.time.sleep')
+    def test_aFloatLatencyIsApplied(self, mock_sleep):
+        for clause, seconds in [(1000, 1.0), (1000.0, 1.0), (10.5, .0105),
+                                ("1000", 1.0), ("1000.0", 1.0), (1, .001)]:
+            with self.subTest(latency=clause):
+                mock_sleep.reset_mock()
+
+                assert self.latency(clause) == True, f"latency {clause!r} must be applied"
+                mock_sleep.assert_called_once_with(seconds)
+
+    @patch('failureflags.time.sleep')
+    def test_aFloatMsIsApplied(self, mock_sleep):
+        for clause, seconds in [({"ms": 500}, .5), ({"ms": 500.0}, .5),
+                                ({"ms": "500"}, .5), ({"ms": 500.5}, .5005)]:
+            with self.subTest(latency=clause):
+                mock_sleep.reset_mock()
+
+                assert self.latency(clause) == True, f"latency {clause!r} must be applied"
+                mock_sleep.assert_called_once_with(seconds)
+
+    @patch('failureflags.time.sleep')
+    def test_aClauseWithNoDelayIsNotImpact(self, mock_sleep):
+        # claiming impact for a clause that resolves to no delay reports a fault to Gremlin
+        # that the application never felt
+        for clause in [{}, {"ms": None}, {"ms": "abc"}, {"ms": []}, {"jitter": "abc"},
+                       0, 0.0, "0", -1000, -1000.5, "-1000", {"ms": -500},
+                       {"ms": 0, "jitter": 0}, True, False, None, [], "abc", "", {"ms": True}]:
+            with self.subTest(latency=clause):
+                assert self.latency(clause) == False, f"latency {clause!r} is not impact"
+
+        mock_sleep.assert_not_called()
+
+    @patch('failureflags.time.sleep')
+    def test_negativeJitterIsClampedNotSlept(self, mock_sleep):
+        # time.sleep() raises ValueError on a negative, and impacted was already True
+        assert self.latency({"ms": 10, "jitter": -100000}) == True
+        (seconds,), _ = mock_sleep.call_args
+        assert seconds == .01, f"jitter must not pull the delay below ms, slept {seconds}"
+
+    @patch('failureflags.time.sleep')
+    def test_jitterAloneIsApplied(self, mock_sleep):
+        assert self.latency({"jitter": 1000}) == True
+        (seconds,), _ = mock_sleep.call_args
+        assert 0 <= seconds <= 1, f"jitter must stay inside its bound, slept {seconds}"
+
+    @patch('failureflags.time.sleep')
+    def test_nonFiniteLatencyIsRejected(self, mock_sleep):
+        # time.sleep(inf) hangs the caller forever, which is the one thing this library
+        # must never do
+        for clause in ["inf", "-inf", "nan", "Infinity", 1e309,
+                       {"ms": "inf"}, {"ms": float("nan")}, {"jitter": "inf"}]:
+            with self.subTest(latency=clause):
+                assert self.latency(clause) == False, f"latency {clause!r} must be rejected"
+
+        mock_sleep.assert_not_called()
+
+class TestRateSelection(unittest.TestCase):
+
+    def test_anAbsentRateMeansAlways(self):
+        # matching the Go and Node SDKs. Requiring a rate made a payload without one a
+        # silent no-op that still reported active.
+        for experiment in [{"effect": {}}, {"rate": None, "effect": {}}]:
+            with self.subTest(experiment=experiment):
+                assert failureflags.isSelected(experiment, .999999) == True
+
+    def test_aRateIsHonoured(self):
+        assert failureflags.isSelected({"rate": 1}, .999999) == True
+        assert failureflags.isSelected({"rate": 0}, 0) == False
+        assert failureflags.isSelected({"rate": .5}, .25) == True
+        assert failureflags.isSelected({"rate": .5}, .75) == False
+
+    def test_aMalformedRateIsNotSelected(self):
+        for rate in ["1", "0.5", 7, -0.5, 1.5, True, False, [], {},
+                     float("nan"), float("inf"), float("-inf")]:
+            with self.subTest(rate=rate):
+                assert failureflags.isSelected({"rate": rate}, 0) == False, f"rate {rate!r}"
+
+    def test_aNonObjectExperimentIsNotSelected(self):
+        for experiment in ["hello", 7, None, [], True]:
+            with self.subTest(experiment=experiment):
+                assert failureflags.isSelected(experiment, 0) == False
+
 if __name__ == '__main__':
         unittest.main()

--- a/test/behaviors_test.py
+++ b/test/behaviors_test.py
@@ -218,6 +218,130 @@ class TestFailureFlagsBehaviors(unittest.TestCase):
             return
         assert False, "An exception must be raised if the experiment provides a valid exception clause"
 
+    def test_exceptionDocumentedNameKey(self):
+        # the payload from the error-metadata docs: `name`, not `className`
+        try:
+            failureflags.exception(failureflags.FailureFlag("name", {}, debug=True), [{
+                "guid": "6884c0df-ed70-4bc8-84c0-dfed703bc8a8",
+                "failureFlagName": "name",
+                "rate": 1,
+                "effect": {
+                    "exception": {
+                        "message": "this is a custom error",
+                        "name": "TimeoutError"
+                    }
+                }}])
+        except Exception as err:
+            assert err.args[0] == "this is a custom error"
+            assert err.__class__.__name__ == "TimeoutError"
+            return
+        assert False, "An exception must be raised if the experiment provides a valid exception clause"
+
+    def test_exceptionNameWithModule(self):
+        try:
+            failureflags.exception(failureflags.FailureFlag("name", {}, debug=True), [{
+                "rate": 1,
+                "effect": {
+                    "exception": {
+                        "module": "http.client",
+                        "name": "ImproperConnectionState",
+                        "message": "this is an improper connection state error"
+                    }
+                }}])
+        except Exception as err:
+            assert err.args[0] == "this is an improper connection state error"
+            assert err.__class__.__name__ == "ImproperConnectionState"
+            return
+        assert False, "An exception must be raised if the experiment provides a valid exception clause"
+
+    def test_exceptionClassNameBeatsName(self):
+        try:
+            failureflags.exception(failureflags.FailureFlag("name", {}, debug=True), [{
+                "rate": 1,
+                "effect": {
+                    "exception": {
+                        "name": "TimeoutError",
+                        "className": "KeyError",
+                        "message": "className wins"
+                    }
+                }}])
+        except Exception as err:
+            assert err.__class__.__name__ == "KeyError"
+            return
+        assert False, "An exception must be raised if the experiment provides a valid exception clause"
+
+    def test_exceptionUnloadableNameStillRaises(self):
+        # a name that exists in no module: raising nothing would report impact while the
+        # application saw no failure at all
+        try:
+            failureflags.exception(failureflags.FailureFlag("name", {}, debug=True), [{
+                "rate": 1,
+                "effect": {
+                    "exception": {
+                        "name": "CustomErrorType",
+                        "message": "this is a custom error"
+                    }
+                }}])
+        except Exception as err:
+            assert err.args[0] == "this is a custom error"
+            assert err.__class__.__name__ == "ValueError"
+            return
+        assert False, "An unloadable exception name must still raise something"
+
+    def test_exceptionUnloadableModuleStillRaises(self):
+        try:
+            failureflags.exception(failureflags.FailureFlag("name", {}, debug=True), [{
+                "rate": 1,
+                "effect": {
+                    "exception": {
+                        "module": "no.such.module",
+                        "className": "TimeoutError",
+                        "message": "this is a custom error"
+                    }
+                }}])
+        except Exception as err:
+            assert err.args[0] == "this is a custom error"
+            assert err.__class__.__name__ == "ValueError"
+            return
+        assert False, "An unloadable module must still raise something"
+
+    def test_exceptionExplicitlyEmptyClassNameRaisesNothing(self):
+        impacted = failureflags.exception(failureflags.FailureFlag("name", {}, debug=True), [{
+            "rate": 1,
+            "effect": {
+                "exception": {
+                    "className": "",
+                    "message": "this should not be raised"
+                }
+            }}])
+        assert impacted == False, "an explicitly empty className opts out of the exception effect"
+
+    def test_exceptionEmptyClauseRaisesNothing(self):
+        impacted = failureflags.exception(failureflags.FailureFlag("name", {}, debug=True), [{
+            "rate": 1,
+            "effect": {
+                "exception": {}
+            }}])
+        assert impacted == False, "an unpopulated exception clause opts out of the exception effect"
+
+    def test_exceptionNonExceptionClassNameStillRaisesCleanly(self):
+        # `str` loads fine but is not an exception type: raising it would throw a TypeError
+        # of the SDK's own making out of the caller's line
+        try:
+            failureflags.exception(failureflags.FailureFlag("name", {}, debug=True), [{
+                "rate": 1,
+                "effect": {
+                    "exception": {
+                        "className": "str",
+                        "message": "this is a custom error"
+                    }
+                }}])
+        except Exception as err:
+            assert err.args[0] == "this is a custom error"
+            assert err.__class__.__name__ == "ValueError"
+            return
+        assert False, "A className that is not an exception type must still raise something"
+
     ##################################################
     # Testing the delayedDataOrError behavior
     ##################################################
@@ -242,6 +366,21 @@ class TestFailureFlagsBehaviors(unittest.TestCase):
             assert err.args[0] == "this is a test message"
             return
         assert False, "An exception must be raised if the experiment provides a valid exception clause"
+
+    @patch('failureflags.time.sleep')
+    def test_behaviorsSkipExperimentsWithoutADictEffect(self, mock_sleep):
+        # a malformed effect must not stop the effects that follow it in the list
+        experiments = [
+            {"rate": 1, "effect": None},
+            {"rate": 1, "effect": "latency"},
+            {"rate": 1, "effect": {"latency": 10000, "exception": "this is a test message"}}]
+        try:
+            failureflags.delayedDataOrError(failureflags.FailureFlag("name", {}, debug=True), experiments)
+        except Exception as err:
+            mock_sleep.assert_called_with(10)
+            assert err.args[0] == "this is a test message"
+            return
+        assert False, "the well-formed experiment in the list must still be applied"
 
 if __name__ == '__main__':
         unittest.main()

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -29,6 +29,60 @@ class TestResolveEndpoint(unittest.TestCase):
         for port in ["0", "-1", "70000", "abc", "80.5", ""]:
             assert failureflags.resolveEndpoint(None, None, None, port) == DEFAULT_ENDPOINT, f"port {port!r}"
 
+class TestParsePort(unittest.TestCase):
+    """GREMLIN_SIDECAR_PORT is a *listen address* to the sidecar, which requires a colon.
+    Parsing it as a plain integer silently discarded every value the sidecar accepts."""
+
+    def test_theFormsTheSidecarAcceptsAllResolveToTheSamePort(self):
+        for raw in ["6032", ":6032", "0.0.0.0:6032", "localhost:6032", "127.0.0.1:6032",
+                    "[::]:6032", " :6032 ", ":6032 "]:
+            with self.subTest(port=raw):
+                assert failureflags.parsePort(raw) == 6032, f"port {raw!r}"
+
+    def test_theHostHalfIsIgnored(self):
+        # a listen address says what the sidecar binds, not where to reach it, and 0.0.0.0
+        # is not a connect target. GREMLIN_SIDECAR_HOST moves the host.
+        assert failureflags.resolveEndpoint(None, None, None, "0.0.0.0:6032") == \
+            "http://localhost:6032/experiment"
+        assert failureflags.resolveEndpoint(None, None, "sidecar", ":6032") == \
+            "http://sidecar:6032/experiment"
+
+    def test_junkFallsBackToTheDefault(self):
+        for raw in ["", ":", "abc", ":abc", "host:", "0", ":0", "-1", ":-1", "70000",
+                    ":70000", "80.5", ":80.5", "6032:6033:", "::"]:
+            with self.subTest(port=raw):
+                assert failureflags.parsePort(raw) is None, f"port {raw!r}"
+
+    def test_listenAddressFormsReachTheSameEndpointAsABarePort(self):
+        bare = failureflags.resolveEndpoint(None, None, None, "6032")
+        for raw in [":6032", "0.0.0.0:6032", "localhost:6032"]:
+            with self.subTest(port=raw):
+                assert failureflags.resolveEndpoint(None, None, None, raw) == bare, \
+                    f"port {raw!r} must resolve where a bare port does"
+
+class TestEndpointScheme(unittest.TestCase):
+
+    def test_onlyHttpIsHonoured(self):
+        # urlopen would happily honour file:// or ftp://, so a misconfigured endpoint must
+        # fall back rather than read a local file and parse it as experiments
+        for endpoint in ["file:///etc/passwd", "ftp://host/x", "data:,[]", "gopher://x",
+                         "not a url", "//host/x"]:
+            with self.subTest(endpoint=endpoint):
+                assert failureflags.resolveEndpoint(endpoint, None, None, None) == \
+                    DEFAULT_ENDPOINT, f"endpoint {endpoint!r}"
+                assert failureflags.resolveEndpoint(None, endpoint, None, None) == \
+                    DEFAULT_ENDPOINT, f"endpoint {endpoint!r}"
+
+    def test_httpAndHttpsPassThrough(self):
+        for endpoint in ["http://host:1/experiment", "https://host:1/experiment",
+                         "HTTP://host:1/experiment"]:
+            with self.subTest(endpoint=endpoint):
+                assert failureflags.resolveEndpoint(endpoint, None, None, None) == endpoint
+
+    def test_aRejectedEndpointStillHonoursHostAndPort(self):
+        assert failureflags.resolveEndpoint("file:///etc/passwd", None, "sidecar", ":6032") == \
+            "http://sidecar:6032/experiment"
+
 class TestResolveTimeout(unittest.TestCase):
 
     def test_defaultWhenNothingIsConfigured(self):

--- a/test/config_test.py
+++ b/test/config_test.py
@@ -1,0 +1,107 @@
+import failureflags
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+DEFAULT_ENDPOINT = "http://localhost:5032/experiment"
+
+class TestResolveEndpoint(unittest.TestCase):
+
+    def test_defaultWhenNothingIsConfigured(self):
+        assert failureflags.resolveEndpoint(None, None, None, None) == DEFAULT_ENDPOINT
+
+    def test_precedence(self):
+        explicit = "http://explicit:1/experiment"
+        variable = "http://variable:2/experiment"
+        assert failureflags.resolveEndpoint(explicit, variable, "host", "3") == explicit
+        assert failureflags.resolveEndpoint(None, variable, "host", "3") == variable
+        assert failureflags.resolveEndpoint(None, None, "host", "3") == "http://host:3/experiment"
+
+    def test_hostAndPortMayBeSetAlone(self):
+        assert failureflags.resolveEndpoint(None, None, "sidecar", None) == "http://sidecar:5032/experiment"
+        assert failureflags.resolveEndpoint(None, None, None, "6000") == "http://localhost:6000/experiment"
+
+    def test_blankValuesAreTreatedAsUnset(self):
+        assert failureflags.resolveEndpoint("", "  ", "", " ") == DEFAULT_ENDPOINT
+
+    def test_junkPortFallsBackToTheDefault(self):
+        # bad configuration must not take the application with it
+        for port in ["0", "-1", "70000", "abc", "80.5", ""]:
+            assert failureflags.resolveEndpoint(None, None, None, port) == DEFAULT_ENDPOINT, f"port {port!r}"
+
+class TestResolveTimeout(unittest.TestCase):
+
+    def test_defaultWhenNothingIsConfigured(self):
+        assert failureflags.resolveTimeout(None, None) == failureflags.DEFAULT_TIMEOUT
+
+    def test_precedenceAndUnits(self):
+        # the argument is seconds, the environment variable is milliseconds
+        assert failureflags.resolveTimeout(2, "250") == 2
+        assert failureflags.resolveTimeout(None, "250") == .25
+        assert failureflags.resolveTimeout(None, "1") == .001
+
+    def test_junkFallsBackToTheDefault(self):
+        for raw in ["0", "-1", "abc", "", "  "]:
+            assert failureflags.resolveTimeout(None, raw) == failureflags.DEFAULT_TIMEOUT, f"timeout {raw!r}"
+        for explicit in [0, -1, "5", True, None]:
+            assert failureflags.resolveTimeout(explicit, None) == failureflags.DEFAULT_TIMEOUT, f"timeout {explicit!r}"
+
+class TestFetchUsesResolvedConfiguration(unittest.TestCase):
+
+    def setUp(self):
+        body = b"[]"
+        self.url_cm = MagicMock()
+        self.url_cm.status = 200
+        self.url_cm.read = MagicMock(return_value=body)
+        self.url_cm.headers.get = MagicMock(side_effect=lambda key, default=None: {
+            "Content-Type": "application/json",
+            "Content-Length": str(len(body))
+        }.get(key, default))
+        self.url_cm.__enter__.return_value = self.url_cm
+
+    @patch('failureflags.urlopen')
+    @patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "TRUE"})
+    def test_defaultEndpointAndTimeout(self, mock_urlopen):
+        mock_urlopen.return_value = self.url_cm
+
+        failureflags.FailureFlag("name", {}, debug=True).fetch()
+
+        request = mock_urlopen.call_args.args[0]
+        assert request.full_url == DEFAULT_ENDPOINT
+        assert mock_urlopen.call_args.kwargs["timeout"] == failureflags.DEFAULT_TIMEOUT
+
+    @patch('failureflags.urlopen')
+    @patch.dict(os.environ, {
+        "FAILURE_FLAGS_ENABLED": "TRUE",
+        "GREMLIN_SIDECAR_HOST": "sidecar",
+        "GREMLIN_SIDECAR_PORT": "6000",
+        "FAILURE_FLAGS_TIMEOUT_MS": "250"})
+    def test_environmentConfiguresTheSidecarAndDeadline(self, mock_urlopen):
+        mock_urlopen.return_value = self.url_cm
+
+        failureflags.FailureFlag("name", {}, debug=True).fetch()
+
+        request = mock_urlopen.call_args.args[0]
+        assert request.full_url == "http://sidecar:6000/experiment"
+        assert mock_urlopen.call_args.kwargs["timeout"] == .25
+
+    @patch('failureflags.urlopen')
+    @patch.dict(os.environ, {
+        "FAILURE_FLAGS_ENABLED": "TRUE",
+        "FAILURE_FLAGS_ENDPOINT": "http://from-variable:1/experiment",
+        "FAILURE_FLAGS_TIMEOUT_MS": "250"})
+    def test_keywordArgumentsBeatTheEnvironment(self, mock_urlopen):
+        mock_urlopen.return_value = self.url_cm
+
+        failureflags.FailureFlag(
+            "name", {},
+            debug=True,
+            timeout=.5,
+            endpoint="http://from-argument:2/experiment").fetch()
+
+        request = mock_urlopen.call_args.args[0]
+        assert request.full_url == "http://from-argument:2/experiment"
+        assert mock_urlopen.call_args.kwargs["timeout"] == .5
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/enabled_test.py
+++ b/test/enabled_test.py
@@ -1,0 +1,67 @@
+import failureflags
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+def jsonResponse(body):
+    """Builds a mock urlopen context manager that answers with `body`."""
+    url_cm = MagicMock()
+    url_cm.status = 200
+    url_cm.read = MagicMock(return_value=body)
+    url_cm.headers.get = MagicMock(side_effect=lambda key, default=None: {
+        "Content-Type": "application/json",
+        "Content-Length": str(len(body))
+    }.get(key, default))
+    url_cm.__enter__.return_value = url_cm
+    return url_cm
+
+class TestEnabled(unittest.TestCase):
+
+    def test_isEnabledAcceptsTheDocumentedValues(self):
+        for raw in ["true", "TRUE", "True", " true ", "yes", "YES", "1", " 1 "]:
+            assert failureflags.isEnabled(raw) == True, f"{raw!r} should enable the SDK"
+
+    def test_isEnabledRejectsEverythingElse(self):
+        # "false" is the value the install docs tell proxy-mode users to set. It must
+        # never enable the SDK.
+        for raw in [None, "", " ", "false", "FALSE", "no", "0", "banana", "truthy", "2"]:
+            assert failureflags.isEnabled(raw) == False, f"{raw!r} should not enable the SDK"
+
+    @patch('failureflags.urlopen')
+    @patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "false"})
+    def test_invokeIsInertWhenExplicitlyDisabled(self, mock_urlopen):
+        mock_urlopen.return_value = jsonResponse(b'[{"rate":1,"effect":{"latency":1}}]')
+
+        flag = failureflags.FailureFlag("name", {}, debug=True)
+        active, impacted, experiments = flag.invoke()
+
+        assert flag.enabled == False, "FAILURE_FLAGS_ENABLED=false must not enable the SDK"
+        mock_urlopen.assert_not_called()
+        assert (active, impacted, experiments) == (False, False, [])
+
+    @patch('failureflags.urlopen')
+    def test_enabledIsReadFromTheEnvironmentOnEveryCall(self, mock_urlopen):
+        mock_urlopen.return_value = jsonResponse(b'[]')
+
+        # constructed while the SDK is disabled, the way a module-level flag is built
+        # before the process environment is fully configured
+        with patch.dict(os.environ, clear=True):
+            flag = failureflags.FailureFlag("name", {}, debug=True)
+            assert flag.enabled == False
+
+        with patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "1"}):
+            assert flag.enabled == True
+            flag.invoke()
+
+        mock_urlopen.assert_called()
+
+    @patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "true"})
+    def test_enabledIsReadOnly(self):
+        # through 1.0.3 this was a plain attribute; the README documents the migration
+        flag = failureflags.FailureFlag("name", {}, debug=True)
+        with self.assertRaises(AttributeError):
+            flag.enabled = False
+        assert flag.enabled == True
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/failsafe_test.py
+++ b/test/failsafe_test.py
@@ -1,0 +1,159 @@
+import logging
+
+import failureflags
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+debug = logging.getLogger("failureflags")
+debug.addHandler(logging.StreamHandler())
+debug.setLevel(logging.DEBUG)
+
+def httpResponse(body=b"[]", status=200, contentType="application/json", contentLength=None):
+    """Builds a mock urlopen context manager with full control over the status line and the
+    headers, so the header validation in fetch() can be exercised directly."""
+    headers = {}
+    if contentType is not None:
+        headers["Content-Type"] = contentType
+    if contentLength is None and body is not None:
+        contentLength = str(len(body))
+    if contentLength is not None:
+        headers["Content-Length"] = contentLength
+    url_cm = MagicMock()
+    url_cm.status = status
+    url_cm.read = MagicMock(return_value=body)
+    url_cm.headers.get = MagicMock(side_effect=lambda key, default=None: headers.get(key, default))
+    url_cm.__enter__.return_value = url_cm
+    return url_cm
+
+EXPERIMENT = b'[{"rate":1,"effect":{"latency":10000}}]'
+
+class TestNameIsNotTrusted(unittest.TestCase):
+    """invoke() promises never to raise unless an experiment says so. A name out of a dict
+    .get() or a config lookup is an ordinary way to arrive holding None."""
+
+    @patch('failureflags.urlopen')
+    @patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "TRUE"})
+    def test_aNonStringNameDoesNotRaise(self, mock_urlopen):
+        mock_urlopen.return_value = httpResponse(EXPERIMENT)
+
+        for name in [None, 7, 7.5, [], {}, b"bytes", True, ""]:
+            with self.subTest(name=name):
+                flag = failureflags.FailureFlag(name, {}, debug=True)
+
+                assert flag.invoke() == (False, False, []), f"name {name!r}"
+
+        mock_urlopen.assert_not_called(), "an unusable name must not reach the sidecar"
+
+    @patch('failureflags.urlopen')
+    @patch('failureflags.time.sleep')
+    @patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "TRUE"})
+    def test_aNonCallableBehaviorDoesNotRaise(self, mock_sleep, mock_urlopen):
+        mock_urlopen.return_value = httpResponse(EXPERIMENT)
+
+        for behavior in ["defaultBehavior", 7, {}, []]:
+            with self.subTest(behavior=behavior):
+                flag = failureflags.FailureFlag("name", {}, behavior=behavior, debug=True)
+                active, impacted, experiments = flag.invoke()
+
+                assert active == True, f"behavior {behavior!r}: the experiment was fetched"
+                assert impacted == False, f"behavior {behavior!r}: nothing could be applied"
+                assert len(experiments) == 1
+
+        mock_sleep.assert_not_called()
+
+class TestLabelsAreNotTrusted(unittest.TestCase):
+
+    @patch('failureflags.urlopen')
+    @patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "TRUE"})
+    def test_labelsOfTheWrongTypeDoNotRaise(self, mock_urlopen):
+        import json
+
+        for labels in [None, "notadict", 7, ["a", "b"]]:
+            with self.subTest(labels=labels):
+                mock_urlopen.return_value = httpResponse(b"[]")
+
+                assert failureflags.FailureFlag("name", labels, debug=True).fetch() == []
+
+                sent = json.loads(mock_urlopen.call_args.args[0].data.decode("utf-8"))
+                assert sent["labels"] == {
+                    "failure-flags-sdk-version": f"python-{failureflags.VERSION}"
+                }, f"labels {labels!r} should not have been sent"
+
+class TestContentTypeIsAMediaType(unittest.TestCase):
+    """`application/json; charset=utf-8` is legal and common. Matching the whole header
+    exactly meant one proxy adding a parameter would silence the SDK fleet-wide."""
+
+    @patch('failureflags.urlopen')
+    @patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "TRUE"})
+    def test_parametersAndCasingAreIgnored(self, mock_urlopen):
+        for header in ["application/json",
+                       "application/json; charset=utf-8",
+                       "application/json;charset=utf-8",
+                       "Application/JSON; charset=UTF-8",
+                       "  application/json  ",
+                       "application/json ; charset=utf-8"]:
+            with self.subTest(contentType=header):
+                mock_urlopen.return_value = httpResponse(EXPERIMENT, contentType=header)
+
+                experiments = failureflags.FailureFlag("name", {}, debug=True).fetch()
+
+                assert len(experiments) == 1, f"Content-Type {header!r} should be accepted"
+
+    @patch('failureflags.urlopen')
+    @patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "TRUE"})
+    def test_aDifferentMediaTypeIsStillRejected(self, mock_urlopen):
+        for header in ["text/html", "text/html; charset=utf-8", "", None,
+                       "application/jsonp", "application/json+ld"]:
+            with self.subTest(contentType=header):
+                mock_urlopen.return_value = httpResponse(EXPERIMENT, contentType=header)
+
+                assert failureflags.FailureFlag("name", {}, debug=True).fetch() == [], \
+                    f"Content-Type {header!r} should be rejected"
+
+    @patch('failureflags.urlopen')
+    @patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "TRUE"})
+    def test_theNoExperimentCaseIsQuiet(self, mock_urlopen):
+        # the sidecar answers "no experiments" with a bare 204, so the header validation
+        # below it used to log a scary line on every single call
+        mock_urlopen.return_value = httpResponse(
+            body=b"", status=204, contentType=None, contentLength=None)
+
+        with self.assertLogs("failureflags", level="DEBUG") as captured:
+            assert failureflags.FailureFlag("name", {}, debug=True).fetch() == []
+
+        noise = [m for m in captured.output if "unexpected Content-Type" in m
+                                            or "invalid Content-Length" in m]
+        assert noise == [], f"204 should not look like a problem: {noise}"
+
+class TestBodyIsNotTrusted(unittest.TestCase):
+
+    @patch('failureflags.urlopen')
+    @patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "TRUE"})
+    def test_aWhitespaceOnlyBodyDoesNotRaise(self, mock_urlopen):
+        # a positive Content-Length with a blank body reached json.loads("") and raised out
+        # of the public fetch()
+        for body in [b"   ", b"\n", b" \t\r\n "]:
+            with self.subTest(body=body):
+                mock_urlopen.return_value = httpResponse(body)
+
+                assert failureflags.FailureFlag("name", {}, debug=True).fetch() == []
+
+    @patch('failureflags.urlopen')
+    @patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "TRUE"})
+    def test_aWhitespaceOnlyBodyIsNotImpact(self, mock_urlopen):
+        mock_urlopen.return_value = httpResponse(b"   ")
+
+        assert failureflags.FailureFlag("name", {}, debug=True).invoke() == (False, False, [])
+
+    @patch('failureflags.urlopen')
+    @patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "TRUE"})
+    def test_aScalarBodyIsNotAnExperiment(self, mock_urlopen):
+        for body in [b"7", b'"hello"', b"null", b"true"]:
+            with self.subTest(body=body):
+                mock_urlopen.return_value = httpResponse(body)
+
+                assert failureflags.FailureFlag("name", {}, debug=True).fetch() == []
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/flag_test.py
+++ b/test/flag_test.py
@@ -1,0 +1,49 @@
+import failureflags
+import json
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+class TestFailureFlag(unittest.TestCase):
+
+    def test_dataIsNotSharedBetweenFlags(self):
+        a = failureflags.FailureFlag("a", {"x": "1"})
+        b = failureflags.FailureFlag("b", {"y": "2"})
+
+        a.data["leaked"] = "from a"
+
+        assert b.data == {}, "flags built without an explicit data= must not share one dict"
+        assert failureflags.FailureFlag("c", {}).data == {}
+
+    def test_dataUsesTheProvidedDict(self):
+        provided = {"k": "v"}
+        assert failureflags.FailureFlag("a", {}, data=provided).data is provided
+
+    @patch('failureflags.urlopen')
+    @patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "TRUE"})
+    def test_fetchDoesNotMutateTheCallersLabels(self, mock_urlopen):
+        body = b"[]"
+        url_cm = MagicMock()
+        url_cm.status = 200
+        url_cm.read = MagicMock(return_value=body)
+        url_cm.headers.get = MagicMock(side_effect=lambda key, default=None: {
+            "Content-Type": "application/json",
+            "Content-Length": str(len(body))
+        }.get(key, default))
+        url_cm.__enter__.return_value = url_cm
+        mock_urlopen.return_value = url_cm
+
+        # the natural way to label by deployment: one dict, reused
+        caller = {"method": "GET"}
+        failureflags.FailureFlag("name", caller, debug=True).fetch()
+
+        assert caller == {"method": "GET"}, "fetch must not write into the caller's dict"
+
+        # ... and the sidecar still gets the version label
+        request = mock_urlopen.call_args.args[0]
+        sent = json.loads(request.data.decode("utf-8"))
+        assert sent["labels"]["method"] == "GET"
+        assert sent["labels"]["failure-flags-sdk-version"] == f"python-{failureflags.VERSION}"
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/invoke_test.py
+++ b/test/invoke_test.py
@@ -10,6 +10,18 @@ debug = logging.getLogger("failureflags")
 debug.addHandler(logging.StreamHandler())
 debug.setLevel(logging.DEBUG)
 
+def jsonResponse(body):
+    """Builds a mock urlopen context manager that answers with `body`."""
+    url_cm = MagicMock()
+    url_cm.status = 200
+    url_cm.read = MagicMock(return_value=body)
+    url_cm.headers.get = MagicMock(side_effect=lambda key, default=None: {
+        "Content-Type": "application/json",
+        "Content-Length": str(len(body))
+    }.get(key, default))
+    url_cm.__enter__.return_value = url_cm
+    return url_cm
+
 class TestInvoke(unittest.TestCase):
 
     @patch('failureflags.urlopen')
@@ -127,6 +139,49 @@ class TestInvoke(unittest.TestCase):
         url_cm.read.assert_called()
         evidence.assert_called()
         mock_sleep.assert_called_with(10)
+
+    @patch('failureflags.urlopen')
+    @patch('failureflags.time.sleep')
+    @patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "TRUE"})
+    def test_experimentWithoutARateDoesNotRaise(self, mock_sleep, mock_urlopen):
+        # the sidecar response is not trusted input: invoke() promises never to raise on
+        # its own, so a malformed experiment is reported but not applied
+        mock_urlopen.return_value = jsonResponse(b'[{"effect":{"latency":10000}}]')
+
+        flag = failureflags.FailureFlag("name", {}, debug=True)
+        active, impacted, experiments = flag.invoke()
+
+        mock_sleep.assert_not_called()
+        assert active == True, "an experiment was returned, so the flag is active"
+        assert impacted == False, "an experiment with no rate must not be applied"
+        assert len(experiments) == 1
+
+    @patch('failureflags.urlopen')
+    @patch('failureflags.time.sleep')
+    @patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "TRUE"})
+    def test_nonDictExperimentsDoNotRaise(self, mock_sleep, mock_urlopen):
+        mock_urlopen.return_value = jsonResponse(b'["hello", 7, null]')
+
+        flag = failureflags.FailureFlag("name", {}, debug=True)
+        active, impacted, experiments = flag.invoke()
+
+        mock_sleep.assert_not_called()
+        assert active == True
+        assert impacted == False
+        assert len(experiments) == 3
+
+    @patch('failureflags.urlopen')
+    @patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "TRUE"})
+    def test_fetchErrorIsLoggedNotFormattedIntoAnError(self, mock_urlopen):
+        mock_urlopen.side_effect = OSError("boom")
+
+        flag = failureflags.FailureFlag("name", {}, debug=True)
+        # assertLogs formats each record, which is where a bad debug() call blows up
+        with self.assertLogs("failureflags", level="DEBUG") as logged:
+            active, impacted, experiments = flag.invoke()
+
+        assert (active, impacted, experiments) == (False, False, [])
+        assert "boom" in "\n".join(logged.output)
 
 if __name__ == '__main__':
         unittest.main()

--- a/test/invoke_test.py
+++ b/test/invoke_test.py
@@ -143,18 +143,44 @@ class TestInvoke(unittest.TestCase):
     @patch('failureflags.urlopen')
     @patch('failureflags.time.sleep')
     @patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "TRUE"})
-    def test_experimentWithoutARateDoesNotRaise(self, mock_sleep, mock_urlopen):
-        # the sidecar response is not trusted input: invoke() promises never to raise on
-        # its own, so a malformed experiment is reported but not applied
+    def test_experimentWithoutARateIsApplied(self, mock_sleep, mock_urlopen):
+        # an absent rate means 1.0, matching the Go and Node SDKs. Skipping it made the
+        # Python SDK report an active experiment that injected nothing, which is the
+        # silent no-op this release exists to remove.
         mock_urlopen.return_value = jsonResponse(b'[{"effect":{"latency":10000}}]')
 
         flag = failureflags.FailureFlag("name", {}, debug=True)
         active, impacted, experiments = flag.invoke()
 
-        mock_sleep.assert_not_called()
+        mock_sleep.assert_called_once_with(10)
         assert active == True, "an experiment was returned, so the flag is active"
-        assert impacted == False, "an experiment with no rate must not be applied"
+        assert impacted == True, "an experiment with no rate must be applied"
         assert len(experiments) == 1
+
+    @patch('failureflags.urlopen')
+    @patch('failureflags.time.sleep')
+    @patch.dict(os.environ, {"FAILURE_FLAGS_ENABLED": "TRUE"})
+    def test_experimentWithAMalformedRateIsNotApplied(self, mock_sleep, mock_urlopen):
+        # a rate that is present but unusable is malformed: fail closed rather than guess
+        # which direction the operator meant
+        for raw in [b'"1"', b'7', b'-0.5', b'true', b'{}', b'null']:
+            with self.subTest(rate=raw):
+                mock_sleep.reset_mock()
+                mock_urlopen.return_value = jsonResponse(
+                    b'[{"rate":' + raw + b',"effect":{"latency":10000}}]')
+
+                flag = failureflags.FailureFlag("name", {}, debug=True)
+                active, impacted, experiments = flag.invoke()
+
+                assert active == True, f"rate {raw!r}: an experiment was returned"
+                assert len(experiments) == 1
+                if raw == b'null':
+                    # null is absent, which means 1.0
+                    mock_sleep.assert_called_once_with(10)
+                    assert impacted == True, "a null rate means always"
+                else:
+                    mock_sleep.assert_not_called()
+                    assert impacted == False, f"rate {raw!r} must not be applied"
 
     @patch('failureflags.urlopen')
     @patch('failureflags.time.sleep')


### PR DESCRIPTION
**Background**
FAILURE_FLAGS_ENABLED was checked for presence, not value, so the documented =false left fault injection live.

**Changes**
Parse it (true/yes/1), read it per call, and make `enabled` a read-only property.

Also: `name` now aliases `className` in exception effects and an unloadable class still raises something; invoke() no longer raises KeyError or TypeError on malformed sidecar payloads; fetch() copies labels instead of annotating the caller's dict; `data` defaults to None; fixed a logger.debug() call that broke logging itself.

New: FAILURE_FLAGS_ENDPOINT, GREMLIN_SIDECAR_HOST/PORT, FAILURE_FLAGS_TIMEOUT_MS.